### PR TITLE
12-byte IVs

### DIFF
--- a/src/main/java/net/jomemo/axolotl/XmppAxolotlMessage.java
+++ b/src/main/java/net/jomemo/axolotl/XmppAxolotlMessage.java
@@ -148,7 +148,7 @@ public class XmppAxolotlMessage {
 
 	private static byte[] generateIv() {
 		SecureRandom random = new SecureRandom();
-		byte[] iv = new byte[16];
+		byte[] iv = new byte[12];
 		random.nextBytes(iv);
 		return iv;
 	}


### PR DESCRIPTION
The XEP-0384 0.3.0 does not specify the "IV" value and the 0.3.1 version has been missing before the 0.4.0 version.
All OMEMO 0.3.0 clients must send with 12-byte instead 16-byte IV.